### PR TITLE
feat: removing the default value for version-filter

### DIFF
--- a/src/extBrowse/Browse.js
+++ b/src/extBrowse/Browse.js
@@ -90,7 +90,7 @@ class Browse extends Component {
         <div className="ext-filters">
           <div className="filter-label">Extension API version</div>
           <FormControl
-            defaultValue={query.api_version === undefined ? '2.0.0' : query.api_version}
+            defaultValue={query.api_version === undefined ? '' : query.api_version}
             onChange={this.onAPIVersionSelect}
             className="version-filter"
             componentClass="select"


### PR DESCRIPTION
### Summary of the changes in this PR

This should happens because we're returning all "any" items by default, then doesn't make sense to set **v2.0.0 (Ulauncher v5)** as selected by default.